### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,6 +19,10 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
     <% if @items.present? %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to "#" do %>
+          <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <% if item.image.attached? %>
                 <%= image_tag item.image, class: "item-img" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= "description" %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= "current_user" %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= "category_id" %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= "condition_id" %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= "shipping_fee_id" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= "prefecture_id" %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= "days_until_shipping_i" %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,13 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class:"item-box-img" if @item.image.attached? %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <% if @item.sold_out? %>
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
       <% end %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -24,26 +22,28 @@
         <%= @item.shipping_fee.name %>
       </span>
     </div>
-
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-    <% if user_signed_in? && current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
-            <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-    <% elsif user_signed_in? %>
-      <%= link_to "購入画面に進む", new_item_order_path(@item) ,class:"item-red-btn" %>
-    <% end %>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+      <% if user_signed_in? && !@item.sold_out? %>
+        <% if current_user.id == @item.user_id %>
+          <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+          <p class="or-text">or</p>
+          <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <% else %>
+          <%= link_to "購入画面に進む", new_item_order_path(@item), class:"item-red-btn" %>
+        <% end %>
+      <% elsif user_signed_in? && @item.sold_out? %>
+        <%# 売却済みの場合は何も表示しない %>
+      <% else %>
+        <%# ログアウト状態では何も表示しない %>
+        <p>ログインしてください</p>
+      <% end %>
     <div class="item-explain-box">
-      <span><%= "description" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "current_user" %></td>
+          <td class="detail-value"><%= @item.user.name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,13 +28,10 @@
           <p class="or-text">or</p>
           <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
         <% else %>
-          <%= link_to "購入画面に進む", new_item_order_path(@item), class:"item-red-btn" %>
+          <%= link_to "購入画面に進む", new_item_path(@item), class:"item-red-btn" %>
         <% end %>
       <% elsif user_signed_in? && @item.sold_out? %>
-        <%# 売却済みの場合は何も表示しない %>
       <% else %>
-        <%# ログアウト状態では何も表示しない %>
-        <p>ログインしてください</p>
       <% end %>
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -43,27 +40,28 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @item.user.name %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "category_id" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "condition_id" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
+
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "shipping_fee_id" %></td>
+          <td class="detail-value"><%= @item.shipping_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "prefecture_id" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "days_until_shipping_i" %></td>
+          <td class="detail-value"><%= @item.days_until_shipping.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,35 +4,35 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+    <%= @item.name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" if @item.image.attached? %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
+      <% if @item.sold_out? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+      ¥ <%= @item.price %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_fee.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
-    <p class="or-text">or</p>
-    <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
+        <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+            <p class="or-text">or</p>
+        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+    <% elsif user_signed_in? %>
+      <%= link_to "購入画面に進む", new_item_order_path(@item) ,class:"item-red-btn" %>
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,7 +8,7 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image, class:"item-box-img" if @item.image.attached? %>
-      <% if @item.sold_out? %>
+      <%# <% if @item.sold_out? %> %>
         <div class="sold-out">
           <span>Sold Out!!</span>
         </div>
@@ -22,7 +22,7 @@
         <%= @item.shipping_fee.name %>
       </span>
     </div>
-      <% if user_signed_in? && !@item.sold_out? %>
+      <%# <% if user_signed_in? && !@item.sold_out? %> %>
         <% if current_user.id == @item.user_id %>
           <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
@@ -101,7 +101,7 @@
     </a>
   </div>
   <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
   <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -22,7 +22,7 @@
         <%= @item.shipping_fee.name %>
       </span>
     </div>
-      <%# <% if user_signed_in? && !@item.sold_out? %> %>
+      <% if user_signed_in? <% =begin %>&& !@item.sold_out?<% =end%> %>
         <% if current_user.id == @item.user_id %>
           <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
@@ -30,7 +30,7 @@
         <% else %>
           <%= link_to "購入画面に進む", "#", class:"item-red-btn" %>
         <% end %>
-      <% elsif user_signed_in? && @item.sold_out? %>
+      <% elsif user_signed_in? <% =begin %>&& @item.sold_out?<% =end%> %>
       <% else %>
       <% end %>
     <div class="item-explain-box">
@@ -100,9 +100,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
   <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,11 +24,11 @@
     </div>
       <% if user_signed_in? && !@item.sold_out? %>
         <% if current_user.id == @item.user_id %>
-          <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
+          <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
           <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
         <% else %>
-          <%= link_to "購入画面に進む", new_item_path(@item), class:"item-red-btn" %>
+          <%= link_to "購入画面に進む", "#", class:"item-red-btn" %>
         <% end %>
       <% elsif user_signed_in? && @item.sold_out? %>
       <% else %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -115,6 +115,26 @@ RSpec.describe Item, type: :model do
         @item.valid?
         expect(@item.errors.full_messages).to include("User must exist")
       end
+
+
+
+
+
+      it "returns true if there is a purchase record" do
+        user = FactoryBot.create(:user)
+        item = FactoryBot.create(:item, user: user)
+        FactoryBot.create(:purchase_record, item: item, user: user)
+      
+        expect(item.sold_out?).to be true
+      end
+      
+    
+      it "returns false if there is no purchase record" do
+        user = FactoryBot.create(:user)
+        item = FactoryBot.create(:item, user: user)
+      
+        expect(item.sold_out?).to be false
+      end
     end
   end
 end


### PR DESCRIPTION
# What
・商品ページに遷移するようにした。
・ユーザーの状態で条件分岐した。
・商品ページで適切な情報が閲覧できるようにした。
# Why
ユーザーが製品を理解しやすくなり、疑問点や不明点の解消、商品比較して購入や出品を選択できるようにするため


https://gyazo.com/39d00a4ae73d698056f9f59091b1e444
👆 ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画

https://gyazo.com/a83bedd94e45d1e56170b111c51ca2dd
👆 ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画

https://gyazo.com/5a81835daaa17f22901f48ab67773c54
👆 ログアウト状態で、商品詳細ページへ遷移した動画
 
※未実装： ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画